### PR TITLE
Use stored summaries for placement

### DIFF
--- a/__tests__/lib/mcp/tools.test.ts
+++ b/__tests__/lib/mcp/tools.test.ts
@@ -53,7 +53,7 @@ describe('MCP Tools', () => {
 
       expect(toolCapabilities.create_action.description).toBe('Create a new action in the database with optional parent and dependencies');
       expect(toolCapabilities.update_parent.description).toBe('Update an action\'s parent relationship by moving it under a new parent or making it a root action');
-      expect(toolCapabilities.suggest_parent.description).toBe('Get an intelligent placement suggestion for a new action using semantic analysis');
+      expect(toolCapabilities.suggest_parent.description).toBe('Get an intelligent placement suggestion for a new action using stored summaries and semantic analysis');
     });
   });
 

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -357,7 +357,7 @@ export function registerTools(server: any) {
   // suggest_parent - Get intelligent placement suggestion for a new action
   server.tool(
     "suggest_parent",
-    "Get an intelligent placement suggestion for a new action using semantic analysis",
+    "Get an intelligent placement suggestion for a new action using stored summaries and semantic analysis",
     {
       title: z.string().min(1).describe("The title for the new action"),
       description: z.string().optional().describe("Detailed description of what the action involves"),
@@ -381,9 +381,13 @@ export function registerTools(server: any) {
         // Convert to the format expected by PlacementService
         const hierarchyItems = existingActions.map((action: any) => ({
           id: action.id,
-          title: action.data?.title || '',
-          description: action.data?.description,
-          vision: action.data?.vision,
+          title: action.title ?? action.data?.title ?? '',
+          description: action.description ?? action.data?.description,
+          vision: action.vision ?? action.data?.vision,
+          nodeSummary: action.nodeSummary,
+          subtreeSummary: action.subtreeSummary,
+          parentContextSummary: action.parentContextSummary,
+          parentVisionSummary: action.parentVisionSummary,
           parentId: action.data?.parent_id
         }));
         
@@ -477,6 +481,6 @@ export const toolCapabilities = {
     description: "Update an action's parent relationship by moving it under a new parent or making it a root action",
   },
   suggest_parent: {
-    description: "Get an intelligent placement suggestion for a new action using semantic analysis",
+    description: "Get an intelligent placement suggestion for a new action using stored summaries and semantic analysis",
   },
 };

--- a/lib/services/placement.ts
+++ b/lib/services/placement.ts
@@ -26,6 +26,10 @@ export interface ActionHierarchyItem {
   title: string;
   description?: string;
   vision?: string;
+  nodeSummary?: string;
+  subtreeSummary?: string;
+  parentContextSummary?: string;
+  parentVisionSummary?: string;
   parentId?: string;
 }
 
@@ -87,6 +91,10 @@ export class PlacementService {
    */
   private static buildParentContext(parent: ActionHierarchyItem, children: ActionHierarchyItem[], allActions: ActionHierarchyItem[]): string {
     let context = `**${parent.title}**\n`;
+    if (parent.nodeSummary) context += `Node Summary: ${parent.nodeSummary}\n`;
+    if (parent.subtreeSummary) context += `Subtree Summary: ${parent.subtreeSummary}\n`;
+    if (parent.parentContextSummary) context += `Context Summary: ${parent.parentContextSummary}\n`;
+    if (parent.parentVisionSummary) context += `Vision Summary: ${parent.parentVisionSummary}\n`;
     if (parent.description) context += `Description: ${parent.description}\n`;
     if (parent.vision) context += `Vision: ${parent.vision}\n`;
     


### PR DESCRIPTION
## Summary
- pass stored summary fields to placement service
- include summary text in parent context prompts
- update tool description and tests

## Testing
- `npm test`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_68570d6f90fc83239738e38da70ef24d