### PR TITLE
Add PGlite test directory cleanup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,7 @@ const customJestConfig = {
     },
   },
   testTimeout: 30000,
+  globalTeardown: '<rootDir>/scripts/cleanup-test-dbs.mjs',
   // Remove parallelism restrictions for speed - fix race conditions instead
 }
 

--- a/scripts/cleanup-test-dbs.mjs
+++ b/scripts/cleanup-test-dbs.mjs
@@ -1,0 +1,19 @@
+import { readdirSync, rmSync } from 'fs';
+import { join } from 'path';
+
+export default async function globalTeardown() {
+  const cwd = process.cwd();
+  const entries = readdirSync(cwd, { withFileTypes: true });
+  const patterns = [/^\.pglite-adapter-test/, /^custom-adapter-test/];
+
+  for (const entry of entries) {
+    if (entry.isDirectory() && patterns.some((p) => p.test(entry.name))) {
+      try {
+        rmSync(join(cwd, entry.name), { recursive: true, force: true });
+        console.log(`Cleaned up temporary directory: ${entry.name}`);
+      } catch (err) {
+        console.warn(`Failed to remove ${entry.name}:`, err);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a global Jest teardown script that removes any `.pglite-adapter-test*` and `custom-adapter-test*` directories
- wire the teardown script into Jest configuration

## Testing
- `pnpm test:pre-commit`

------
https://chatgpt.com/codex/tasks/task_b_68571695613c83239652187006e96cb8