### PR TITLE
Fix completion flow on action pages

### DIFF
--- a/__tests__/app/next-page.test.tsx
+++ b/__tests__/app/next-page.test.tsx
@@ -197,12 +197,21 @@ describe('NextActionDisplay', () => {
       })
     });
 
+    // Fourth call for suggestions fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true, data: mockActionData })
+    });
+
     const markCompleteButton = screen.getByLabelText('Mark Complete');
     fireEvent.click(markCompleteButton);
 
     await waitFor(() => {
       expect(screen.getByText('Action Completed! 🎉')).toBeInTheDocument();
-      expect(screen.getByText('Loading next action...')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestions-modal')).toBeInTheDocument();
     });
 
     // Verify the PUT request was made

--- a/__tests__/app/next/components/NextActionDisplay.test.tsx
+++ b/__tests__/app/next/components/NextActionDisplay.test.tsx
@@ -312,7 +312,7 @@ describe('NextActionDisplay Error Handling', () => {
     });
   });
 
-  it('should reload page after successful completion with delay', async () => {
+  it('should show suggestions modal after successful completion', async () => {
     // First call succeeds for initial fetch
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -339,6 +339,14 @@ describe('NextActionDisplay Error Handling', () => {
         data: { ...mockNextActionData, done: true }
       })
     });
+    // Fourth call for fetching next suggestions
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        success: true,
+        data: mockNextActionData
+      })
+    });
 
     render(<NextActionDisplay colors={mockColors} />);
 
@@ -350,15 +358,11 @@ describe('NextActionDisplay Error Handling', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Action Completed! 🎉')).toBeInTheDocument();
-      expect(screen.getByText('Loading next action...')).toBeInTheDocument();
     });
 
-    // Fast-forward timers to trigger the reload (timeout is tested even if reload itself can't be)
-    jest.advanceTimersByTime(1500);
-    
-    // Verify the completion message is still shown
-    expect(screen.getByText('Action Completed! 🎉')).toBeInTheDocument();
-    expect(screen.getByText('Loading next action...')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('suggestions-modal')).toBeInTheDocument();
+    });
   });
 
   it('should handle missing MCP error message gracefully', async () => {


### PR DESCRIPTION
## Summary
- show completion suggestions instead of reloading action pages
- track liberated actions and display them in a modal
- adjust tests for new modal behaviour

## Testing
- `npx jest __tests__/app/next/components/NextActionDisplay.test.tsx --runInBand`
- `npx jest __tests__/app/next-page.test.tsx --runInBand`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68572feb50588323b8671b705867adee