### PR TITLE
Highlight next child task in action view

### DIFF
--- a/__tests__/api/actions-next-id.test.ts
+++ b/__tests__/api/actions-next-id.test.ts
@@ -1,0 +1,83 @@
+import { GET } from '../../app/api/actions/next/[id]/route';
+import { ActionsService } from '../../lib/services/actions';
+
+jest.mock('../../lib/services/actions', () => ({
+  ActionsService: {
+    getNextActionScoped: jest.fn(),
+    getActionDetailResource: jest.fn(),
+  },
+}));
+
+const mockedService = ActionsService as jest.Mocked<typeof ActionsService>;
+
+describe('/api/actions/next/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns next child action when one exists', async () => {
+    const mockAction = {
+      id: 'child-id',
+      data: { title: 'Child Action' },
+      done: false,
+      version: 1,
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    };
+
+    const mockDetails = {
+      id: 'child-id',
+      title: 'Child Action',
+      done: false,
+      version: 1,
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-01-01T00:00:00Z',
+      parent_id: 'parent-id',
+      parent_chain: [],
+      children: [],
+      dependencies: [],
+      dependents: [],
+      parent_context_summary: 'context',
+      parent_vision_summary: 'vision',
+    };
+
+    mockedService.getNextActionScoped.mockResolvedValue(mockAction as any);
+    mockedService.getActionDetailResource.mockResolvedValue(mockDetails as any);
+
+    const request = new Request('http://localhost/api/actions/next/parent-id');
+    const response = await GET(request, { params: Promise.resolve({ id: 'parent-id' }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual(mockDetails);
+    expect(mockedService.getNextActionScoped).toHaveBeenCalledWith('parent-id');
+    expect(mockedService.getActionDetailResource).toHaveBeenCalledWith('child-id');
+  });
+
+  it('returns null when no next child exists', async () => {
+    mockedService.getNextActionScoped.mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/actions/next/parent-id');
+    const response = await GET(request, { params: Promise.resolve({ id: 'parent-id' }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toBe(null);
+    expect(mockedService.getNextActionScoped).toHaveBeenCalledWith('parent-id');
+    expect(mockedService.getActionDetailResource).not.toHaveBeenCalled();
+  });
+
+  it('handles errors gracefully', async () => {
+    mockedService.getNextActionScoped.mockRejectedValue(new Error('DB failed'));
+
+    const request = new Request('http://localhost/api/actions/next/parent-id');
+    const response = await GET(request, { params: Promise.resolve({ id: 'parent-id' }) });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe('DB failed');
+  });
+});

--- a/__tests__/components/NextActionDisplay.test.tsx
+++ b/__tests__/components/NextActionDisplay.test.tsx
@@ -259,4 +259,51 @@ describe('NextActionDisplay', () => {
     // Check that the component renders successfully
     expect(screen.getByText('Broader Context')).toBeInTheDocument();
   });
+
+  it('should highlight the next child action when scoped', async () => {
+    const mockAction = {
+      id: 'parent-id',
+      title: 'Parent Action',
+      description: 'desc',
+      vision: 'vision',
+      done: false,
+      version: 1,
+      created_at: '2023-01-01T00:00:00.000Z',
+      updated_at: '2023-01-01T00:00:00.000Z',
+      parent_id: null,
+      parent_chain: [],
+      children: [
+        {
+          id: 'child-1',
+          title: 'Child 1',
+          description: '',
+          vision: '',
+          done: false,
+          version: 1,
+          created_at: '2023-01-01T00:00:00.000Z',
+          updated_at: '2023-01-01T00:00:00.000Z'
+        }
+      ],
+      dependencies: [],
+      dependents: []
+    };
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: mockAction })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data: { id: 'child-1', parent_id: 'parent-id' } })
+      });
+
+    render(<NextActionDisplay colors={mockColors} actionId="parent-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Child 1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('next-child-indicator')).toBeInTheDocument();
+  });
 });

--- a/app/api/actions/next/[id]/route.ts
+++ b/app/api/actions/next/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ActionsService } from "../../../../../lib/services/actions";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const resolvedParams = await params;
+    const scopeId = resolvedParams.id;
+
+    const nextAction = await ActionsService.getNextActionScoped(scopeId);
+
+    if (!nextAction) {
+      return NextResponse.json({
+        success: true,
+        data: null
+      });
+    }
+
+    const actionDetails = await ActionsService.getActionDetailResource(nextAction.id);
+
+    const enhancedActionDetails = {
+      ...actionDetails,
+      parent_context_summary: actionDetails.parent_context_summary || 'This action has no parent context.',
+      parent_vision_summary: actionDetails.parent_vision_summary || 'This action has no parent vision context.'
+    };
+
+    return NextResponse.json({
+      success: true,
+      data: enhancedActionDetails
+    });
+  } catch (error) {
+    console.error('Error getting scoped next action:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error"
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/next/components/ActionNavigation.tsx
+++ b/app/next/components/ActionNavigation.tsx
@@ -6,9 +6,10 @@ interface Props {
   action: ActionDetailResource;
   siblings: ActionMetadata[];
   colors: ColorScheme;
+  nextChildId?: string | null;
 }
 
-export default function ActionNavigation({ action, siblings, colors }: Props) {
+export default function ActionNavigation({ action, siblings, colors, nextChildId }: Props) {
   const hasParents = action.parent_chain && action.parent_chain.length > 0;
   const hasChildren = action.children && action.children.length > 0;
   const hasSiblings = siblings && siblings.length > 0;
@@ -150,6 +151,11 @@ export default function ActionNavigation({ action, siblings, colors }: Props) {
                   <span style={{ textDecoration: child.done ? 'line-through' : 'none', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {child.title}
                   </span>
+                  {nextChildId === child.id && (
+                    <span data-testid="next-child-indicator" style={{ fontSize: '0.625rem', color: colors.borderAccent, fontWeight: 600 }}>
+                      Next Action
+                    </span>
+                  )}
                 </a>
               ))}
             </div>

--- a/app/next/components/NextActionDisplay.tsx
+++ b/app/next/components/NextActionDisplay.tsx
@@ -32,6 +32,7 @@ export default function NextActionDisplay({ colors, actionId }: Props) {
   const [isMobile, setIsMobile] = useState(false);
   const [savingVision, setSavingVision] = useState(false);
   const [savingDescription, setSavingDescription] = useState(false);
+  const [nextChildId, setNextChildId] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchAction = async () => {
@@ -59,6 +60,22 @@ export default function NextActionDisplay({ colors, actionId }: Props) {
           }
         } else {
           setSiblings([]);
+        }
+
+        if (actionId) {
+          try {
+            const nextResp = await fetch(`/api/actions/next/${actionId}`);
+            if (nextResp.ok) {
+              const nextData = await nextResp.json();
+              if (nextData.success && nextData.data && nextData.data.parent_id === actionId) {
+                setNextChildId(nextData.data.id);
+              } else {
+                setNextChildId(null);
+              }
+            }
+          } catch (nextErr) {
+            console.error('Error fetching next child action:', nextErr);
+          }
         }
       } catch (err) {
         console.error(`Error fetching ${actionId ? 'action' : 'next action'}:`, err);
@@ -390,7 +407,7 @@ export default function NextActionDisplay({ colors, actionId }: Props) {
           )}
         </button>
       </div>
-      <ActionNavigation action={actionData} siblings={siblings} colors={colors} />
+      <ActionNavigation action={actionData} siblings={siblings} colors={colors} nextChildId={nextChildId} />
       {showModal && (
         <div data-testid="suggestions-modal" style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}>
           <div style={{ backgroundColor: 'white', padding: '1rem', borderRadius: '0.5rem', maxWidth: '90%', width: '24rem', boxShadow: '0 2px 6px rgba(0,0,0,0.2)' }}>


### PR DESCRIPTION
## Summary
- fetch scoped next action via `/api/actions/next/[id]`
- pass next child id to `ActionNavigation`
- label the next actionable child
- add REST endpoint for scoped next action
- test highlighting of next child task

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6857ed333f048323872f5225ce3299e3