### PR TITLE
Add basic logo and favicon

### DIFF
--- a/app/favicon.ico/route.ts
+++ b/app/favicon.ico/route.ts
@@ -1,5 +1,0 @@
-import { NextResponse } from 'next/server';
-
-export async function GET() {
-  return new NextResponse(null, { status: 204 });
-}

--- a/app/favicon.png/route.ts
+++ b/app/favicon.png/route.ts
@@ -1,5 +1,0 @@
-import { NextResponse } from 'next/server';
-
-export async function GET() {
-  return new NextResponse(null, { status: 204 });
-}

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#ffffff"/>
+  <text x="16" y="22" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#1c1c1c" text-anchor="middle">AB</text>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,9 @@ export const metadata: Metadata = {
     title: "ActionBias - AI-Forward Planning System",
     description: "AI-forward planning that persists across conversations",
   },
+  icons: {
+    icon: "/icon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import Logo from '../components/Logo';
+
 export default function HomePage() {
   return (
     <div className="min-h-screen" style={{ backgroundColor: 'var(--color-bg)', color: 'var(--color-fg)' }}>
@@ -5,7 +7,7 @@ export default function HomePage() {
         <header className="mb-16">
           <div className="flex items-center justify-between mb-8">
             <h1 className="text-2xl font-mono font-semibold">
-              actionbias.ai
+              <Logo />
             </h1>
             <nav className="flex items-center space-x-6 text-sm font-mono">
               <a 

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,5 @@
+export default function Logo() {
+  return (
+    <img src="/logo.svg" alt="ActionBias logo" style={{ height: '1.5rem' }} />
+  );
+}

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="40" viewBox="0 0 180 40">
+  <text x="0" y="28" font-family="Helvetica, Arial, sans-serif" font-size="28" font-weight="700" fill="#1c1c1c">Action</text>
+  <text x="100" y="28" font-family="Helvetica, Arial, sans-serif" font-size="28" font-weight="700" fill="#666666">Bias</text>
+</svg>


### PR DESCRIPTION
## Summary
- create simple grayscale logo SVG
- add favicon as icon.svg
- remove placeholder favicon routes
- embed Logo component in home page
- register new icon in app metadata

## Testing
- `pnpm test` *(fails: Error getting next action: Database connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_6859e40ec77883238cbafe588cb86efa