### PR TITLE
Integrate Claude Code prompt

### DIFF
--- a/__tests__/app/next/components/NextActionDisplay.test.tsx
+++ b/__tests__/app/next/components/NextActionDisplay.test.tsx
@@ -485,7 +485,7 @@ describe('NextActionDisplay Error Handling', () => {
     });
   });
 
-  it('should include resource URLs in codex prompt', async () => {
+  it('should include resource URLs in Claude Code prompt', async () => {
     // Mock navigator.clipboard.writeText
     Object.assign(navigator, {
       clipboard: {
@@ -515,10 +515,10 @@ describe('NextActionDisplay Error Handling', () => {
     render(<NextActionDisplay colors={mockColors} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Copy Action Instructions for Codex')).toBeInTheDocument();
+      expect(screen.getByText('Copy Action Instructions for Claude Code')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('Copy Action Instructions for Codex'));
+    fireEvent.click(screen.getByText('Copy Action Instructions for Claude Code'));
 
     await waitFor(() => {
       expect(writeTextSpy).toHaveBeenCalled();

--- a/__tests__/components/NextActionDisplay.test.tsx
+++ b/__tests__/components/NextActionDisplay.test.tsx
@@ -196,7 +196,7 @@ describe('NextActionDisplay', () => {
 
     // Verify that buttons are rendered
     expect(screen.getByRole('button', { name: /Copy Full Context for Claude Code/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Copy Action Instructions for Codex/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy Action Instructions for Claude Code/ })).toBeInTheDocument();
   });
 
   it('should render with navigation links', async () => {

--- a/__tests__/lib/mcp/prompts.test.ts
+++ b/__tests__/lib/mcp/prompts.test.ts
@@ -1,0 +1,37 @@
+import { registerPrompts, promptCapabilities } from '../../../lib/mcp/prompts';
+import { ActionsService } from '../../../lib/services/actions';
+
+jest.mock('../../../lib/services/actions');
+
+const mockServer = {
+  prompt: jest.fn(),
+};
+
+describe('MCP Prompts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServer.prompt.mockClear();
+  });
+
+  describe('registerPrompts', () => {
+    it('should register prompts with the server', () => {
+      registerPrompts(mockServer as any);
+      expect(mockServer.prompt).toHaveBeenCalledTimes(1);
+      expect(mockServer.prompt).toHaveBeenCalledWith(
+        'claude-code-next-action',
+        expect.any(String),
+        expect.any(Object),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('promptCapabilities', () => {
+    it('should export correct prompt capabilities', () => {
+      expect(promptCapabilities).toHaveProperty('claude-code-next-action');
+      expect(promptCapabilities['claude-code-next-action'].description).toBe(
+        'Structured prompt summarizing an action with context'
+      );
+    });
+  });
+});

--- a/app/mcp/[transport]/route.ts
+++ b/app/mcp/[transport]/route.ts
@@ -2,16 +2,19 @@ import { createMcpHandler } from "@vercel/mcp-adapter";
 import { authenticatedHandler } from "../../../lib/mcp/auth";
 import { registerResources, resourceCapabilities } from "../../../lib/mcp/resources";
 import { registerTools, toolCapabilities } from "../../../lib/mcp/tools";
+import { registerPrompts, promptCapabilities } from "../../../lib/mcp/prompts";
 
 const handler = createMcpHandler(
   (server) => {
     registerResources(server);
     registerTools(server);
+    registerPrompts(server);
   },
   {
     capabilities: {
       resources: resourceCapabilities,
       tools: toolCapabilities,
+      prompts: promptCapabilities,
     },
   },
   {

--- a/app/next/components/NextActionDisplay.tsx
+++ b/app/next/components/NextActionDisplay.tsx
@@ -213,10 +213,10 @@ export default function NextActionDisplay({ colors, actionId }: Props) {
     else prompt += `\n`;
     prompt += `# Vision\n`;
     prompt += `${action.vision || 'No vision defined for this action.'}\n\n`;
-    prompt += `# Context from Parent Chain\n`;
-    prompt += `${action.parent_context_summary || 'No parent context.'}\n\n`;
-    prompt += `# Broader Vision\n`;
-    prompt += `${action.parent_vision_summary || 'No parent vision context.'}\n\n`;
+    prompt += `# Context from Family Chain\n`;
+    prompt += `${action.parent_context_summary || 'No family context.'}\n\n`;
+    prompt += `# Broader Family Vision\n`;
+    prompt += `${action.parent_vision_summary || 'No family vision context.'}\n\n`;
     
     // Add completion context from dependencies
     if (action.dependency_completion_context && action.dependency_completion_context.length > 0) {
@@ -575,7 +575,7 @@ export default function NextActionDisplay({ colors, actionId }: Props) {
               <svg style={{ width: '16px', height: '16px', color: 'white' }} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
               </svg>
-              Copy Action Instructions for Codex
+              Copy Action Instructions for Claude Code
             </>
           )}
         </button>

--- a/lib/mcp/prompts.ts
+++ b/lib/mcp/prompts.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { ActionsService } from "../services/actions";
+
+export function registerPrompts(server: any) {
+  server.prompt(
+    'claude-code-next-action',
+    'Structured prompt summarizing an action with context',
+    { action_id: z.string().uuid().describe('ID of the action to summarize') },
+    async ({ action_id }: { action_id: string }) => {
+      const action = await ActionsService.getActionDetailResource(action_id);
+
+      let prompt = `# Current Task\n**${action.title}**\n`;
+      if (action.description) prompt += `${action.description}\n\n`;
+      else prompt += `\n`;
+      prompt += `# Vision\n${action.vision || 'No vision defined for this action.'}\n\n`;
+      prompt += `# Context from Family Chain\n${action.parent_context_summary || 'No family context.'}\n\n`;
+      prompt += `# Broader Family Vision\n${action.parent_vision_summary || 'No family vision context.'}\n\n`;
+
+      if (action.dependency_completion_context && action.dependency_completion_context.length > 0) {
+        prompt += `# Completion Context from Dependencies\n`;
+        prompt += `This action builds on completed dependencies:\n\n`;
+        for (const context of action.dependency_completion_context) {
+          prompt += `## ${context.action_title}\n`;
+          if (context.implementation_story) {
+            prompt += `**How it was built:** ${context.implementation_story}\n`;
+          }
+          if (context.impact_story) {
+            prompt += `**Impact:** ${context.impact_story}\n`;
+          }
+          if (context.learning_story) {
+            prompt += `**Learnings:** ${context.learning_story}\n`;
+          }
+          prompt += `\n`;
+        }
+        prompt += `Apply these insights to avoid repeating mistakes and build on successful approaches.\n\n`;
+      }
+
+      prompt += `# Resource URLs\n`;
+      prompt += `- action://tree (full action hierarchy)\n`;
+      prompt += `- action://next (current priority action)\n`;
+      prompt += `- action://${action.id} (this action's details)\n\n`;
+      prompt += `# Repository Quick Setup\n`;
+      prompt += `pnpm install\npnpm db:setup\npnpm dev\n\n`;
+      prompt += `Refer to README.md for full details.`;
+
+      return {
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: prompt,
+            },
+          },
+        ],
+      };
+    }
+  );
+}
+
+export const promptCapabilities = {
+  'claude-code-next-action': {
+    description: 'Structured prompt summarizing an action with context',
+  },
+};


### PR DESCRIPTION
## Summary
- register `claude-code-next-action` prompt
- expose family-based context text in prompt builder
- update NextActionDisplay button text and tests for Claude Code

## Testing
- `npm test --silent` *(fails: 15 failed test suites, 68 failed tests)*

------
https://chatgpt.com/codex/tasks/task_b_6859e44eab708323a5e6adec039e7094